### PR TITLE
add ignore for uploaded image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 
 # Ignore Byebug command history file.
 .byebug_history
+
+# アップロードした画像をIgnore
+public/uploads/*


### PR DESCRIPTION
#What
gitignoreにpublic/uploads/を追加

#Why
アップ画像ファイルをgitで同期する必要がないため